### PR TITLE
Reuse rotation role for Postgres users

### DIFF
--- a/rds-postgres/admin-login/README.md
+++ b/rds-postgres/admin-login/README.md
@@ -28,8 +28,8 @@ suitable for application credentials. We recommend you combine this module with
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_rotation"></a> [rotation](#module\_rotation) | github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.1.0 |  |
-| <a name="module_secret"></a> [secret](#module\_secret) | github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.1.0 |  |
+| <a name="module_rotation"></a> [rotation](#module\_rotation) | github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.2.0 |  |
+| <a name="module_secret"></a> [secret](#module\_secret) | github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.2.0 |  |
 
 ## Resources
 
@@ -64,6 +64,8 @@ suitable for application credentials. We recommend you combine this module with
 |------|-------------|
 | <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | ID of the KMS key used to encrypt the secret |
 | <a name="output_policy_json"></a> [policy\_json](#output\_policy\_json) | Required IAM policies |
+| <a name="output_rotation_role_arn"></a> [rotation\_role\_arn](#output\_rotation\_role\_arn) | ARN of the IAM role allowed to rotate this secret |
+| <a name="output_rotation_role_name"></a> [rotation\_role\_name](#output\_rotation\_role\_name) | Name of the IAM role allowed to rotate this secret |
 | <a name="output_secret_arn"></a> [secret\_arn](#output\_secret\_arn) | ARN of the secrets manager secret containing credentials |
 | <a name="output_secret_name"></a> [secret\_name](#output\_secret\_name) | Name of the secrets manager secret containing credentials |
 <!-- END_TF_DOCS -->

--- a/rds-postgres/admin-login/main.tf
+++ b/rds-postgres/admin-login/main.tf
@@ -1,5 +1,5 @@
 module "secret" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.1.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.2.0"
 
   admin_principals = var.admin_principals
   description      = "Admin Postgres password for: ${local.full_name}"
@@ -19,7 +19,7 @@ module "secret" {
 }
 
 module "rotation" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.1.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.2.0"
 
   handler            = "lambda_function.lambda_handler"
   role_arn           = module.secret.rotation_role_arn

--- a/rds-postgres/admin-login/outputs.tf
+++ b/rds-postgres/admin-login/outputs.tf
@@ -8,6 +8,16 @@ output "policy_json" {
   value       = module.secret.policy_json
 }
 
+output "rotation_role_arn" {
+  description = "ARN of the IAM role allowed to rotate this secret"
+  value       = module.secret.rotation_role_arn
+}
+
+output "rotation_role_name" {
+  description = "Name of the IAM role allowed to rotate this secret"
+  value       = module.secret.rotation_role_name
+}
+
 output "secret_arn" {
   description = "ARN of the secrets manager secret containing credentials"
   value       = module.secret.arn

--- a/rds-postgres/user-login/README.md
+++ b/rds-postgres/user-login/README.md
@@ -29,8 +29,8 @@ rotations.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_rotation"></a> [rotation](#module\_rotation) | github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.1.0 |  |
-| <a name="module_secret"></a> [secret](#module\_secret) | github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.1.0 |  |
+| <a name="module_rotation"></a> [rotation](#module\_rotation) | github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.2.0 |  |
+| <a name="module_secret"></a> [secret](#module\_secret) | github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.2.0 |  |
 
 ## Resources
 
@@ -56,6 +56,7 @@ rotations.
 | <a name="input_grants"></a> [grants](#input\_grants) | List of GRANT statements for this user | `list(string)` | n/a | yes |
 | <a name="input_identifier"></a> [identifier](#input\_identifier) | Identifier of the database for which a login will be managed | `string` | n/a | yes |
 | <a name="input_read_principals"></a> [read\_principals](#input\_read\_principals) | Principals allowed to read the secret (default: current account) | `list(string)` | `null` | no |
+| <a name="input_rotation_role_name"></a> [rotation\_role\_name](#input\_rotation\_role\_name) | IAM role name for the admin rotation role | `string` | n/a | yes |
 | <a name="input_secret_name"></a> [secret\_name](#input\_secret\_name) | Override the name for this secret | `string` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnets in which the rotation function should run | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to created resources | `map(string)` | `{}` | no |

--- a/rds-postgres/user-login/main.tf
+++ b/rds-postgres/user-login/main.tf
@@ -1,12 +1,14 @@
 module "secret" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.1.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.2.0"
 
-  admin_principals = var.admin_principals
-  description      = "Postgres password for: ${local.full_name}"
-  name             = coalesce(var.secret_name, local.full_name)
-  read_principals  = var.read_principals
-  resource_tags    = var.tags
-  trust_tags       = var.trust_tags
+  admin_principals     = var.admin_principals
+  create_rotation_role = false
+  description          = "Postgres password for: ${local.full_name}"
+  name                 = coalesce(var.secret_name, local.full_name)
+  read_principals      = var.read_principals
+  resource_tags        = var.tags
+  rotation_role_name   = var.rotation_role_name
+  trust_tags           = var.trust_tags
 
   initial_value = jsonencode({
     dbname   = var.database_name
@@ -19,7 +21,7 @@ module "secret" {
 }
 
 module "rotation" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.1.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.2.0"
 
   handler            = "lambda_function.lambda_handler"
   role_arn           = module.secret.rotation_role_arn

--- a/rds-postgres/user-login/variables.tf
+++ b/rds-postgres/user-login/variables.tf
@@ -41,6 +41,11 @@ variable "read_principals" {
   default     = null
 }
 
+variable "rotation_role_name" {
+  description = "IAM role name for the admin rotation role"
+  type        = string
+}
+
 variable "secret_name" {
   description = "Override the name for this secret"
   type        = string


### PR DESCRIPTION
Reuse the rotation role from the admin user, as the user login function will need to access the admin and user secrets.
