### PR TITLE
Apply parameter group changes on reboot

### DIFF
--- a/rds-postgres/parameter-group/main.tf
+++ b/rds-postgres/parameter-group/main.tf
@@ -23,8 +23,9 @@ resource "aws_db_parameter_group" "this" {
     for_each = local.parameters
 
     content {
-      name  = parameter.key
-      value = parameter.value
+      apply_method = "pending-reboot"
+      name         = parameter.key
+      value        = parameter.value
     }
   }
 }


### PR DESCRIPTION
The default value in Terraform is "immediately," but many parameters can only be updated by rebooting the instance. This results in a permanent diff where Terraform tries to change the method from "pending-reboot" to "immediately" each time.

This change also causes the rotation function to think that the database instance might change, which causes various policy attachments to be destroyed and reattached on every change.

With this update, I was able to get an empty plan when there were no changes to the underlying instance.
