### PR TITLE
Update to v5.x of terraform-provider-aws

### DIFF
--- a/elasticache-redis/auth-token/main.tf
+++ b/elasticache-redis/auth-token/main.tf
@@ -1,5 +1,5 @@
 module "secret" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.4.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.8.0"
 
   admin_principals = var.admin_principals
   description      = "Redis auth token for: ${local.full_name}"
@@ -16,7 +16,7 @@ module "secret" {
 }
 
 module "rotation" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.4.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.8.0"
 
   handler     = "lambda_function.lambda_handler"
   role_arn    = module.secret.rotation_role_arn

--- a/elasticache-redis/auth-token/versions.tf
+++ b/elasticache-redis/auth-token/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/elasticache-redis/replication-group/main.tf
+++ b/elasticache-redis/replication-group/main.tf
@@ -6,7 +6,7 @@ resource "aws_elasticache_replication_group" "this" {
   description                = var.description
   engine                     = var.engine
   engine_version             = var.engine_version
-  kms_key_id                 = var.kms_key == null ? module.customer_kms.kms_key_arn : var.kms_key.id
+  kms_key_id                 = local.primary_kms_key
   multi_az_enabled           = local.replica_enabled
   node_type                  = var.node_type
   num_cache_clusters         = local.instance_count
@@ -241,4 +241,6 @@ locals {
     local.owned_security_group_ids,
     local.shared_security_group_ids
   )
+
+  primary_kms_key = var.enable_kms ? (var.kms_key == null ? module.customer_kms.kms_key_arn : var.kms_key.id) : var.kms_key
 }

--- a/elasticache-redis/replication-group/main.tf
+++ b/elasticache-redis/replication-group/main.tf
@@ -1,22 +1,23 @@
 resource "aws_elasticache_replication_group" "this" {
   replication_group_id = coalesce(var.replication_group_id, var.name)
 
-  at_rest_encryption_enabled = var.at_rest_encryption_enabled
-  automatic_failover_enabled = local.replica_enabled
-  description                = var.description
-  engine                     = var.engine
-  engine_version             = var.engine_version
-  kms_key_id                 = local.primary_kms_key
-  multi_az_enabled           = local.replica_enabled
-  node_type                  = var.node_type
-  num_cache_clusters         = local.instance_count
-  parameter_group_name       = var.parameter_group_name
-  port                       = var.port
-  security_group_ids         = local.server_security_group_ids
-  snapshot_name              = var.snapshot_name
-  snapshot_retention_limit   = var.snapshot_retention_limit
-  subnet_group_name          = aws_elasticache_subnet_group.this.name
-  transit_encryption_enabled = var.transit_encryption_enabled
+  at_rest_encryption_enabled  = var.at_rest_encryption_enabled
+  automatic_failover_enabled  = local.replica_enabled
+  description                 = var.description
+  engine                      = var.engine
+  engine_version              = var.engine_version
+  global_replication_group_id = var.global_replication_group_id
+  kms_key_id                  = local.primary_kms_key
+  multi_az_enabled            = local.replica_enabled
+  node_type                   = var.node_type
+  num_cache_clusters          = local.instance_count
+  parameter_group_name        = var.parameter_group_name
+  port                        = var.port
+  security_group_ids          = local.server_security_group_ids
+  snapshot_name               = var.snapshot_name
+  snapshot_retention_limit    = var.snapshot_retention_limit
+  subnet_group_name           = aws_elasticache_subnet_group.this.name
+  transit_encryption_enabled  = var.transit_encryption_enabled
 
   # Auth tokens aren't supported without TLS
   auth_token = (

--- a/elasticache-redis/replication-group/main.tf
+++ b/elasticache-redis/replication-group/main.tf
@@ -1,22 +1,22 @@
 resource "aws_elasticache_replication_group" "this" {
   replication_group_id = coalesce(var.replication_group_id, var.name)
 
-  at_rest_encryption_enabled    = var.at_rest_encryption_enabled
-  automatic_failover_enabled    = local.replica_enabled
-  engine                        = var.engine
-  engine_version                = var.engine_version
-  kms_key_id                    = var.kms_key == null ? module.customer_kms.kms_key_arn : var.kms_key.id
-  multi_az_enabled              = local.replica_enabled
-  node_type                     = var.node_type
-  num_cache_clusters            = local.instance_count
-  parameter_group_name          = var.parameter_group_name
-  port                          = var.port
-  replication_group_description = var.description
-  security_group_ids            = local.server_security_group_ids
-  snapshot_name                 = var.snapshot_name
-  snapshot_retention_limit      = var.snapshot_retention_limit
-  subnet_group_name             = aws_elasticache_subnet_group.this.name
-  transit_encryption_enabled    = var.transit_encryption_enabled
+  at_rest_encryption_enabled = var.at_rest_encryption_enabled
+  automatic_failover_enabled = local.replica_enabled
+  description                = var.description
+  engine                     = var.engine
+  engine_version             = var.engine_version
+  kms_key_id                 = var.kms_key == null ? module.customer_kms.kms_key_arn : var.kms_key.id
+  multi_az_enabled           = local.replica_enabled
+  node_type                  = var.node_type
+  num_cache_clusters         = local.instance_count
+  parameter_group_name       = var.parameter_group_name
+  port                       = var.port
+  security_group_ids         = local.server_security_group_ids
+  snapshot_name              = var.snapshot_name
+  snapshot_retention_limit   = var.snapshot_retention_limit
+  subnet_group_name          = aws_elasticache_subnet_group.this.name
+  transit_encryption_enabled = var.transit_encryption_enabled
 
   # Auth tokens aren't supported without TLS
   auth_token = (
@@ -36,7 +36,7 @@ resource "aws_elasticache_replication_group" "this" {
 }
 
 module "customer_kms" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//customer-managed-kms?ref=v0.7.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//customer-managed-kms?ref=v0.8.0"
 
   name = var.name
 }
@@ -229,7 +229,7 @@ data "aws_ec2_instance_type" "instance_attributes" {
 
 locals {
   instance_count            = var.replica_count + 1
-  instance_size             = split(".", var.node_type)[2]
+  instance_size             = replace(var.node_type, "cache.", "")
   instances                 = sort(aws_elasticache_replication_group.this.member_clusters)
   owned_security_group_ids  = module.server_security_group.*.id
   replica_enabled           = var.replica_count > 0

--- a/elasticache-redis/replication-group/main.tf
+++ b/elasticache-redis/replication-group/main.tf
@@ -242,5 +242,5 @@ locals {
     local.shared_security_group_ids
   )
 
-  primary_kms_key = var.enable_kms ? (var.kms_key == null ? module.customer_kms.kms_key_arn : var.kms_key.id) : var.kms_key
+  primary_kms_key = var.enable_kms ? (var.kms_key_id == null ? module.customer_kms.kms_key_arn : var.kms_key_id) : var.kms_key_id
 }

--- a/elasticache-redis/replication-group/variables.tf
+++ b/elasticache-redis/replication-group/variables.tf
@@ -10,9 +10,9 @@ variable "at_rest_encryption_enabled" {
   default     = true
 }
 
-variable "kms_key" {
-  description = "Custom KMS key to encrypt data at rest"
-  type        = object({ arn = string })
+variable "kms_key_id" {
+  description = "KMS key to encrypt data at rest"
+  type        = string
   default     = null
 }
 

--- a/elasticache-redis/replication-group/variables.tf
+++ b/elasticache-redis/replication-group/variables.tf
@@ -38,6 +38,12 @@ variable "engine_version" {
   description = "Version for RDS database engine"
 }
 
+variable "global_replication_group_id" {
+  type        = string
+  description = "The ID of the global replication group to which this replication group should belong."
+  default     = null
+}
+
 variable "initial_auth_token" {
   type        = string
   description = "Override the initial auth token"

--- a/elasticache-redis/replication-group/variables.tf
+++ b/elasticache-redis/replication-group/variables.tf
@@ -21,6 +21,12 @@ variable "description" {
   type        = string
 }
 
+variable "enable_kms" {
+  type        = bool
+  description = "Enable KMS encryption"
+  default     = true
+}
+
 variable "engine" {
   type        = string
   description = "Elasticache database engine; defaults to Redis"

--- a/elasticache-redis/replication-group/versions.tf
+++ b/elasticache-redis/replication-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/kafka/versions.tf
+++ b/kafka/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/rds-postgres/admin-login/main.tf
+++ b/rds-postgres/admin-login/main.tf
@@ -1,5 +1,5 @@
 module "secret" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.4.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.8.0"
 
   admin_principals = var.admin_principals
   description      = "Postgres password for: ${local.full_name}"
@@ -19,7 +19,7 @@ module "secret" {
 }
 
 module "rotation" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.4.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.8.0"
 
   handler     = "lambda_function.lambda_handler"
   role_arn    = module.secret.rotation_role_arn

--- a/rds-postgres/admin-login/versions.tf
+++ b/rds-postgres/admin-login/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/rds-postgres/cloudwatch-alarms/versions.tf
+++ b/rds-postgres/cloudwatch-alarms/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/rds-postgres/parameter-group/versions.tf
+++ b/rds-postgres/parameter-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/rds-postgres/primary-instance/main.tf
+++ b/rds-postgres/primary-instance/main.tf
@@ -51,7 +51,7 @@ resource "aws_db_instance" "this" {
 }
 
 module "customer_kms" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//customer-managed-kms?ref=v0.7.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//customer-managed-kms?ref=v0.8.0"
 
   name = var.identifier
 }

--- a/rds-postgres/primary-instance/main.tf
+++ b/rds-postgres/primary-instance/main.tf
@@ -155,5 +155,5 @@ locals {
     local.shared_vpc_security_group_ids
   )
 
-  primary_kms_key = var.kms_key_id == null ? module.customer_kms.kms_key_arn : var.kms_key_id
+  primary_kms_key = var.enable_kms ? (var.kms_key_id == null ? module.customer_kms.kms_key_arn : var.kms_key_id) : var.kms_key_id
 }

--- a/rds-postgres/primary-instance/variables.tf
+++ b/rds-postgres/primary-instance/variables.tf
@@ -53,6 +53,12 @@ variable "enabled_cloudwatch_logs_exports" {
   default     = []
 }
 
+variable "enable_kms" {
+  type        = bool
+  description = "Enable KMS encryption"
+  default     = true
+}
+
 variable "engine" {
   type        = string
   description = "RDS database engine; defaults to Postgres"

--- a/rds-postgres/primary-instance/versions.tf
+++ b/rds-postgres/primary-instance/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/rds-postgres/rds-postgres-login/main.tf
+++ b/rds-postgres/rds-postgres-login/main.tf
@@ -1,5 +1,5 @@
 module "secret" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.4.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.8.0"
 
   admin_principals = var.admin_principals
   description      = "Postgres password for: ${local.full_name}"
@@ -9,7 +9,7 @@ module "secret" {
   trust_tags       = var.trust_tags
 
   initial_value = jsonencode({
-    dbname   = var.database.name
+    dbname   = var.database.db_name
     engine   = var.database.engine
     host     = var.database.address
     password = ""
@@ -19,7 +19,7 @@ module "secret" {
 }
 
 module "rotation" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.4.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.8.0"
 
   handler            = "lambda_function.lambda_handler"
   role_arn           = module.secret.rotation_role_arn

--- a/rds-postgres/rds-postgres-login/variables.tf
+++ b/rds-postgres/rds-postgres-login/variables.tf
@@ -27,9 +27,9 @@ variable "database" {
   type = object({
     address    = string
     arn        = string
+    db_name    = string
     engine     = string
     identifier = string
-    name       = string
     port       = number
   })
 }

--- a/rds-postgres/rds-postgres-login/versions.tf
+++ b/rds-postgres/rds-postgres-login/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/rds-postgres/replica/versions.tf
+++ b/rds-postgres/replica/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/security-group-ingress/versions.tf
+++ b/security-group-ingress/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/security-group/versions.tf
+++ b/security-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Switch this and dependent modules to the v5.x of the Terraform AWS provider to support the latest AWS features, like RDS' io2.

- Use updated `description` attribute name

Per the [documentation] for resource/aws_elasticache_replication_group

```
Remove availability_zones, number_cache_clusters,
replication_group_description arguments from configurations as they no
longer exist. Use preferred_cache_cluster_azs, num_cache_clusters, and
description, respectively, instead.
```

[documentation]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-5-upgrade#resourceaws_elasticache_replication_group

- Use `db_name` instead of `name`

Change name to db_name in configurations as name no longer exists.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-5-upgrade#use-db_name-instead-of-name

- Fix setting `instance_size`

```
│ Error: reading EC2 Instance Type: operation error EC2: DescribeInstanceTypes, https response error StatusCode: 400, RequestID: c975f413-b3d8-46e7-aad2-36dc1f38e063, api error InvalidInstanceType: The following supplied instance types do not exist: [2xlarge]
│
│   with module.production.module.redis_sidekiq[0].data.aws_ec2_instance_type.instance_attributes,
│   on .terraform/modules/production.redis_sidekiq/elasticache-redis/replication-group/main.tf line 226, in data "aws_ec2_instance_type" "instance_attributes":
│  226: data "aws_ec2_instance_type" "instance_attributes" {
```