### PR TITLE
Optionally override certificate authority for RDS database

### DIFF
--- a/rds-postgres/primary-instance/variables.tf
+++ b/rds-postgres/primary-instance/variables.tf
@@ -38,7 +38,7 @@ variable "backup_window" {
 variable "ca_cert_id" {
   type        = string
   description = "Certificate authority for RDS database"
-  default     = "rds-ca-rsa2048-g1"
+  default     = null
 }
 
 variable "create_default_db" {


### PR DESCRIPTION
When a new RDS database is created, AWS assigns a default certificate to it. We want to default the certificate to AWS' recommendation at the creation moment and then override that certificate version if necessary later.