### PR TITLE
Writes the RDS database URL under a different secret key for replicas

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ Modules:
 
 * [Postgres](./rds-postgres/README.md) (RDS)
   * [Primary Instance](./rds-postgres/primary-instance/README.md)
+  * [Replica Instance](./rds-postgres/replica/README.md)
+  * [Parameter Group](./rds-postgres/parameter-group/README.md)
   * [Admin Login](./rds-postgres/admin-login/README.md)
-  * [User Login](./rds-postgres/user-login/README.md)
+  * [User Login](./rds-postgres/rds-postgres-login/README.md)
+  * [CloudWatch Alarms](./rds-postgres/cloudwatch-alarms/README.md)
 * [Redis](./elasticacahe-redis/README.md) (ElastiCache)
   * [Cluster](./elasticacahe-redis/cluster/README.md)

--- a/rds-postgres/rds-postgres-login/README.md
+++ b/rds-postgres/rds-postgres-login/README.md
@@ -41,6 +41,9 @@ module "rds_admin_password" {
 }
 ```
 
+> [!WARNING]  
+> The [replica](#input\_replica) variable **MUST** be set to `true` when creating a login for a Postgres replica instance. This is needed to ensure the Database URL secret won't conflict with the primary instance. As a result of setting that variable, the Database URL for the replica will be available as "REPLICA_DATABASE_URL", while the primary instance will have "DATABASE_URL".
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -84,6 +87,7 @@ module "rds_admin_password" {
 | <a name="input_database"></a> [database](#input\_database) | The database instance for which a login will be managed | <pre>object({<br>    address    = string<br>    arn        = string<br>    engine     = string<br>    identifier = string<br>    name       = string<br>    port       = number<br>  })</pre> | n/a | yes |
 | <a name="input_grants"></a> [grants](#input\_grants) | List of GRANT statements for this user | `list(string)` | n/a | yes |
 | <a name="input_read_principals"></a> [read\_principals](#input\_read\_principals) | Principals allowed to read the secret (default: current account) | `list(string)` | `null` | no |
+| <a name="input_replica"></a> [replica](#input\_replica) | Whether the login is for a replica instance | `bool` | `false` | no |
 | <a name="input_secret_name"></a> [secret\_name](#input\_secret\_name) | Override the name for this secret | `string` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnets in which the rotation function should run | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to created resources | `map(string)` | `{}` | no |

--- a/rds-postgres/rds-postgres-login/main.tf
+++ b/rds-postgres/rds-postgres-login/main.tf
@@ -38,7 +38,7 @@ module "rotation" {
     ALTERNATE_USERNAME       = coalesce(var.alternate_username, "${var.username}_alt")
     GRANTS                   = jsonencode(var.grants)
     PRIMARY_USERNAME         = var.username
-    DATABASE_URL_SECRET_NAME = local.database_url_secret_name
+    DATABASE_URL_SECRET_KEY = local.database_url_secret_key
   }
 }
 
@@ -102,5 +102,5 @@ data "aws_kms_key" "admin_login" {
 
 locals {
   full_name                = join("-", ["rds-postgres", var.database.identifier, var.username])
-  database_url_secret_name = var.replica ? "REPLICA_DATABASE_URL" : "DATABASE_URL"
+  database_url_secret_key = var.replica ? "REPLICA_DATABASE_URL" : "DATABASE_URL"
 }

--- a/rds-postgres/rds-postgres-login/main.tf
+++ b/rds-postgres/rds-postgres-login/main.tf
@@ -34,10 +34,10 @@ module "rotation" {
   }
 
   variables = {
-    ADMIN_LOGIN_SECRET_ARN   = var.admin_login_secret_arn
-    ALTERNATE_USERNAME       = coalesce(var.alternate_username, "${var.username}_alt")
-    GRANTS                   = jsonencode(var.grants)
-    PRIMARY_USERNAME         = var.username
+    ADMIN_LOGIN_SECRET_ARN  = var.admin_login_secret_arn
+    ALTERNATE_USERNAME      = coalesce(var.alternate_username, "${var.username}_alt")
+    GRANTS                  = jsonencode(var.grants)
+    PRIMARY_USERNAME        = var.username
     DATABASE_URL_SECRET_KEY = local.database_url_secret_key
   }
 }
@@ -101,6 +101,6 @@ data "aws_kms_key" "admin_login" {
 }
 
 locals {
-  full_name                = join("-", ["rds-postgres", var.database.identifier, var.username])
+  full_name               = join("-", ["rds-postgres", var.database.identifier, var.username])
   database_url_secret_key = var.replica ? "REPLICA_DATABASE_URL" : "DATABASE_URL"
 }

--- a/rds-postgres/rds-postgres-login/main.tf
+++ b/rds-postgres/rds-postgres-login/main.tf
@@ -34,10 +34,11 @@ module "rotation" {
   }
 
   variables = {
-    ADMIN_LOGIN_SECRET_ARN = var.admin_login_secret_arn
-    ALTERNATE_USERNAME     = coalesce(var.alternate_username, "${var.username}_alt")
-    GRANTS                 = jsonencode(var.grants)
-    PRIMARY_USERNAME       = var.username
+    ADMIN_LOGIN_SECRET_ARN   = var.admin_login_secret_arn
+    ALTERNATE_USERNAME       = coalesce(var.alternate_username, "${var.username}_alt")
+    GRANTS                   = jsonencode(var.grants)
+    PRIMARY_USERNAME         = var.username
+    DATABASE_URL_SECRET_NAME = local.database_url_secret_name
   }
 }
 
@@ -100,5 +101,6 @@ data "aws_kms_key" "admin_login" {
 }
 
 locals {
-  full_name = join("-", ["rds-postgres", var.database.identifier, var.username])
+  full_name                = join("-", ["rds-postgres", var.database.identifier, var.username])
+  database_url_secret_name = var.replica ? "REPLICA_DATABASE_URL" : "DATABASE_URL"
 }

--- a/rds-postgres/rds-postgres-login/rotation/lambda_function.py
+++ b/rds-postgres/rds-postgres-login/rotation/lambda_function.py
@@ -15,7 +15,7 @@ ADMIN_LOGIN_SECRET_ARN = os.environ['ADMIN_LOGIN_SECRET_ARN']
 ALTERNATE_USERNAME = os.environ['ALTERNATE_USERNAME']
 GRANTS = json.loads(os.environ['GRANTS'])
 PRIMARY_USERNAME = os.environ['PRIMARY_USERNAME']
-DATABASE_URL_SECRET_NAME = os.environ['DATABASE_URL_SECRET_NAME']
+DATABASE_URL_SECRET_KEY = os.environ['DATABASE_URL_SECRET_KEY']
 
 def lambda_handler(event, context):
     """Secrets Manager RDS PostgreSQL Handler
@@ -129,7 +129,7 @@ def create_secret(service_client, arn, token):
         current_dict['password'] = passwd['RandomPassword']
 
         # Add DATABASE_URL to secret
-        current_dict[DATABASE_URL_SECRET_NAME] = dict_to_url(current_dict)
+        current_dict[DATABASE_URL_SECRET_KEY] = dict_to_url(current_dict)
 
         # Put the secret
         service_client.put_secret_value(SecretId=arn, ClientRequestToken=token, SecretString=json.dumps(current_dict), VersionStages=['AWSPENDING'])

--- a/rds-postgres/rds-postgres-login/rotation/lambda_function.py
+++ b/rds-postgres/rds-postgres-login/rotation/lambda_function.py
@@ -15,6 +15,7 @@ ADMIN_LOGIN_SECRET_ARN = os.environ['ADMIN_LOGIN_SECRET_ARN']
 ALTERNATE_USERNAME = os.environ['ALTERNATE_USERNAME']
 GRANTS = json.loads(os.environ['GRANTS'])
 PRIMARY_USERNAME = os.environ['PRIMARY_USERNAME']
+DATABASE_URL_SECRET_NAME = os.environ['DATABASE_URL_SECRET_NAME']
 
 def lambda_handler(event, context):
     """Secrets Manager RDS PostgreSQL Handler
@@ -128,7 +129,7 @@ def create_secret(service_client, arn, token):
         current_dict['password'] = passwd['RandomPassword']
 
         # Add DATABASE_URL to secret
-        current_dict['DATABASE_URL'] = dict_to_url(current_dict)
+        current_dict[DATABASE_URL_SECRET_NAME] = dict_to_url(current_dict)
 
         # Put the secret
         service_client.put_secret_value(SecretId=arn, ClientRequestToken=token, SecretString=json.dumps(current_dict), VersionStages=['AWSPENDING'])

--- a/rds-postgres/rds-postgres-login/variables.tf
+++ b/rds-postgres/rds-postgres-login/variables.tf
@@ -45,6 +45,12 @@ variable "read_principals" {
   default     = null
 }
 
+variable "replica" {
+  description = "Whether the login is for a replica instance"
+  type        = bool
+  default     = false
+}
+
 variable "secret_name" {
   description = "Override the name for this secret"
   type        = string


### PR DESCRIPTION
When creating the postgres login and the rotations for the replica, it will create a DATABASE_URL secret under the new secret object. The problem with that is that it will end up conflicting with the existing DATABASE_URL. As a workaround, we've been configuring an object alias for the secrets to avoid the conflict, which is not obvious and can cause problems if someone forgets to do it.

This adds a boolean variable that tells whether the database is a replica or not. When it is a replica, the key name should be "REPLICA_DATABASE_URL", and when it isn't, it will keep the default "DATABASE_URL".