### PR TITLE
Update to v5.x of terraform-provider-aws

### DIFF
--- a/elasticache-redis/auth-token/README.md
+++ b/elasticache-redis/auth-token/README.md
@@ -16,20 +16,20 @@ token is changed.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_rotation"></a> [rotation](#module\_rotation) | github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function | v0.4.0 |
-| <a name="module_secret"></a> [secret](#module\_secret) | github.com/thoughtbot/terraform-aws-secrets//secret | v0.4.0 |
+| <a name="module_rotation"></a> [rotation](#module\_rotation) | github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function | v0.8.0 |
+| <a name="module_secret"></a> [secret](#module\_secret) | github.com/thoughtbot/terraform-aws-secrets//secret | v0.8.0 |
 | <a name="module_security_group"></a> [security\_group](#module\_security\_group) | ../../security-group | n/a |
 
 ## Resources

--- a/elasticache-redis/auth-token/main.tf
+++ b/elasticache-redis/auth-token/main.tf
@@ -1,5 +1,5 @@
 module "secret" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.4.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.8.0"
 
   admin_principals = var.admin_principals
   description      = "Redis auth token for: ${local.full_name}"
@@ -16,7 +16,7 @@ module "secret" {
 }
 
 module "rotation" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.4.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.8.0"
 
   handler     = "lambda_function.lambda_handler"
   role_arn    = module.secret.rotation_role_arn

--- a/elasticache-redis/auth-token/versions.tf
+++ b/elasticache-redis/auth-token/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/elasticache-redis/replication-group/README.md
+++ b/elasticache-redis/replication-group/README.md
@@ -8,14 +8,14 @@ Provision a Redis cluster using AWS ElastiCache.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 
 ## Modules
@@ -23,7 +23,7 @@ Provision a Redis cluster using AWS ElastiCache.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_client_security_group"></a> [client\_security\_group](#module\_client\_security\_group) | ../../security-group | n/a |
-| <a name="module_customer_kms"></a> [customer\_kms](#module\_customer\_kms) | github.com/thoughtbot/terraform-aws-secrets//customer-managed-kms | v0.7.0 |
+| <a name="module_customer_kms"></a> [customer\_kms](#module\_customer\_kms) | github.com/thoughtbot/terraform-aws-secrets//customer-managed-kms | v0.8.0 |
 | <a name="module_server_security_group"></a> [server\_security\_group](#module\_server\_security\_group) | ../../security-group | n/a |
 
 ## Resources
@@ -50,10 +50,12 @@ Provision a Redis cluster using AWS ElastiCache.
 | <a name="input_create_client_security_group"></a> [create\_client\_security\_group](#input\_create\_client\_security\_group) | Set to false to only use existing security groups | `bool` | `true` | no |
 | <a name="input_create_server_security_group"></a> [create\_server\_security\_group](#input\_create\_server\_security\_group) | Set to false to only use existing security groups | `bool` | `true` | no |
 | <a name="input_description"></a> [description](#input\_description) | Human-readable description for this replication group | `string` | n/a | yes |
+| <a name="input_enable_kms"></a> [enable\_kms](#input\_enable\_kms) | Enable KMS encryption | `bool` | `true` | no |
 | <a name="input_engine"></a> [engine](#input\_engine) | Elasticache database engine; defaults to Redis | `string` | `"redis"` | no |
 | <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Version for RDS database engine | `string` | n/a | yes |
+| <a name="input_global_replication_group_id"></a> [global\_replication\_group\_id](#input\_global\_replication\_group\_id) | The ID of the global replication group to which this replication group should belong. | `string` | `null` | no |
 | <a name="input_initial_auth_token"></a> [initial\_auth\_token](#input\_initial\_auth\_token) | Override the initial auth token | `string` | `null` | no |
-| <a name="input_kms_key"></a> [kms\_key](#input\_kms\_key) | Custom KMS key to encrypt data at rest | `object({ arn = string })` | `null` | no |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | KMS key to encrypt data at rest | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name for this cluster | `string` | n/a | yes |
 | <a name="input_node_type"></a> [node\_type](#input\_node\_type) | Node type for the Elasticache instance | `string` | n/a | yes |
 | <a name="input_parameter_group_name"></a> [parameter\_group\_name](#input\_parameter\_group\_name) | Parameter group name for the Redis cluster | `string` | `null` | no |

--- a/elasticache-redis/replication-group/main.tf
+++ b/elasticache-redis/replication-group/main.tf
@@ -6,7 +6,7 @@ resource "aws_elasticache_replication_group" "this" {
   description                = var.description
   engine                     = var.engine
   engine_version             = var.engine_version
-  kms_key_id                 = var.kms_key == null ? module.customer_kms.kms_key_arn : var.kms_key.id
+  kms_key_id                 = local.primary_kms_key
   multi_az_enabled           = local.replica_enabled
   node_type                  = var.node_type
   num_cache_clusters         = local.instance_count
@@ -241,4 +241,6 @@ locals {
     local.owned_security_group_ids,
     local.shared_security_group_ids
   )
+
+  primary_kms_key = var.enable_kms ? (var.kms_key == null ? module.customer_kms.kms_key_arn : var.kms_key.id) : var.kms_key
 }

--- a/elasticache-redis/replication-group/main.tf
+++ b/elasticache-redis/replication-group/main.tf
@@ -1,22 +1,23 @@
 resource "aws_elasticache_replication_group" "this" {
   replication_group_id = coalesce(var.replication_group_id, var.name)
 
-  at_rest_encryption_enabled = var.at_rest_encryption_enabled
-  automatic_failover_enabled = local.replica_enabled
-  description                = var.description
-  engine                     = var.engine
-  engine_version             = var.engine_version
-  kms_key_id                 = local.primary_kms_key
-  multi_az_enabled           = local.replica_enabled
-  node_type                  = var.node_type
-  num_cache_clusters         = local.instance_count
-  parameter_group_name       = var.parameter_group_name
-  port                       = var.port
-  security_group_ids         = local.server_security_group_ids
-  snapshot_name              = var.snapshot_name
-  snapshot_retention_limit   = var.snapshot_retention_limit
-  subnet_group_name          = aws_elasticache_subnet_group.this.name
-  transit_encryption_enabled = var.transit_encryption_enabled
+  at_rest_encryption_enabled  = var.at_rest_encryption_enabled
+  automatic_failover_enabled  = local.replica_enabled
+  description                 = var.description
+  engine                      = var.engine
+  engine_version              = var.engine_version
+  global_replication_group_id = var.global_replication_group_id
+  kms_key_id                  = local.primary_kms_key
+  multi_az_enabled            = local.replica_enabled
+  node_type                   = var.node_type
+  num_cache_clusters          = local.instance_count
+  parameter_group_name        = var.parameter_group_name
+  port                        = var.port
+  security_group_ids          = local.server_security_group_ids
+  snapshot_name               = var.snapshot_name
+  snapshot_retention_limit    = var.snapshot_retention_limit
+  subnet_group_name           = aws_elasticache_subnet_group.this.name
+  transit_encryption_enabled  = var.transit_encryption_enabled
 
   # Auth tokens aren't supported without TLS
   auth_token = (

--- a/elasticache-redis/replication-group/main.tf
+++ b/elasticache-redis/replication-group/main.tf
@@ -242,5 +242,5 @@ locals {
     local.shared_security_group_ids
   )
 
-  primary_kms_key = var.enable_kms ? (var.kms_key == null ? module.customer_kms.kms_key_arn : var.kms_key.id) : var.kms_key
+  primary_kms_key = var.enable_kms ? (var.kms_key_id == null ? module.customer_kms.kms_key_arn : var.kms_key_id) : var.kms_key_id
 }

--- a/elasticache-redis/replication-group/main.tf
+++ b/elasticache-redis/replication-group/main.tf
@@ -1,22 +1,22 @@
 resource "aws_elasticache_replication_group" "this" {
   replication_group_id = coalesce(var.replication_group_id, var.name)
 
-  at_rest_encryption_enabled    = var.at_rest_encryption_enabled
-  automatic_failover_enabled    = local.replica_enabled
-  engine                        = var.engine
-  engine_version                = var.engine_version
-  kms_key_id                    = var.kms_key == null ? module.customer_kms.kms_key_arn : var.kms_key.id
-  multi_az_enabled              = local.replica_enabled
-  node_type                     = var.node_type
-  num_cache_clusters            = local.instance_count
-  parameter_group_name          = var.parameter_group_name
-  port                          = var.port
-  replication_group_description = var.description
-  security_group_ids            = local.server_security_group_ids
-  snapshot_name                 = var.snapshot_name
-  snapshot_retention_limit      = var.snapshot_retention_limit
-  subnet_group_name             = aws_elasticache_subnet_group.this.name
-  transit_encryption_enabled    = var.transit_encryption_enabled
+  at_rest_encryption_enabled = var.at_rest_encryption_enabled
+  automatic_failover_enabled = local.replica_enabled
+  description                = var.description
+  engine                     = var.engine
+  engine_version             = var.engine_version
+  kms_key_id                 = var.kms_key == null ? module.customer_kms.kms_key_arn : var.kms_key.id
+  multi_az_enabled           = local.replica_enabled
+  node_type                  = var.node_type
+  num_cache_clusters         = local.instance_count
+  parameter_group_name       = var.parameter_group_name
+  port                       = var.port
+  security_group_ids         = local.server_security_group_ids
+  snapshot_name              = var.snapshot_name
+  snapshot_retention_limit   = var.snapshot_retention_limit
+  subnet_group_name          = aws_elasticache_subnet_group.this.name
+  transit_encryption_enabled = var.transit_encryption_enabled
 
   # Auth tokens aren't supported without TLS
   auth_token = (
@@ -36,7 +36,7 @@ resource "aws_elasticache_replication_group" "this" {
 }
 
 module "customer_kms" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//customer-managed-kms?ref=v0.7.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//customer-managed-kms?ref=v0.8.0"
 
   name = var.name
 }
@@ -229,7 +229,7 @@ data "aws_ec2_instance_type" "instance_attributes" {
 
 locals {
   instance_count            = var.replica_count + 1
-  instance_size             = split(".", var.node_type)[2]
+  instance_size             = replace(var.node_type, "cache.", "")
   instances                 = sort(aws_elasticache_replication_group.this.member_clusters)
   owned_security_group_ids  = module.server_security_group[*].id
   replica_enabled           = var.replica_count > 0

--- a/elasticache-redis/replication-group/variables.tf
+++ b/elasticache-redis/replication-group/variables.tf
@@ -10,9 +10,9 @@ variable "at_rest_encryption_enabled" {
   default     = true
 }
 
-variable "kms_key" {
-  description = "Custom KMS key to encrypt data at rest"
-  type        = object({ arn = string })
+variable "kms_key_id" {
+  description = "KMS key to encrypt data at rest"
+  type        = string
   default     = null
 }
 

--- a/elasticache-redis/replication-group/variables.tf
+++ b/elasticache-redis/replication-group/variables.tf
@@ -38,6 +38,12 @@ variable "engine_version" {
   description = "Version for RDS database engine"
 }
 
+variable "global_replication_group_id" {
+  type        = string
+  description = "The ID of the global replication group to which this replication group should belong."
+  default     = null
+}
+
 variable "initial_auth_token" {
   type        = string
   description = "Override the initial auth token"

--- a/elasticache-redis/replication-group/variables.tf
+++ b/elasticache-redis/replication-group/variables.tf
@@ -21,6 +21,12 @@ variable "description" {
   type        = string
 }
 
+variable "enable_kms" {
+  type        = bool
+  description = "Enable KMS encryption"
+  default     = true
+}
+
 variable "engine" {
   type        = string
   description = "Elasticache database engine; defaults to Redis"

--- a/elasticache-redis/replication-group/versions.tf
+++ b/elasticache-redis/replication-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -25,13 +25,13 @@ module "kafka_staging" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 
 ## Modules
 

--- a/kafka/versions.tf
+++ b/kafka/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/rds-postgres/admin-login/README.md
+++ b/rds-postgres/admin-login/README.md
@@ -16,20 +16,20 @@ suitable for application credentials. We recommend you combine this module with
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_rotation"></a> [rotation](#module\_rotation) | github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function | v0.4.0 |
-| <a name="module_secret"></a> [secret](#module\_secret) | github.com/thoughtbot/terraform-aws-secrets//secret | v0.4.0 |
+| <a name="module_rotation"></a> [rotation](#module\_rotation) | github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function | v0.8.0 |
+| <a name="module_secret"></a> [secret](#module\_secret) | github.com/thoughtbot/terraform-aws-secrets//secret | v0.8.0 |
 | <a name="module_security_group"></a> [security\_group](#module\_security\_group) | ../../security-group | n/a |
 
 ## Resources

--- a/rds-postgres/admin-login/main.tf
+++ b/rds-postgres/admin-login/main.tf
@@ -1,5 +1,5 @@
 module "secret" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.4.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.8.0"
 
   admin_principals = var.admin_principals
   description      = "Postgres password for: ${local.full_name}"
@@ -19,7 +19,7 @@ module "secret" {
 }
 
 module "rotation" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.4.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.8.0"
 
   handler     = "lambda_function.lambda_handler"
   role_arn    = module.secret.rotation_role_arn

--- a/rds-postgres/admin-login/versions.tf
+++ b/rds-postgres/admin-login/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/rds-postgres/cloudwatch-alarms/README.md
+++ b/rds-postgres/cloudwatch-alarms/README.md
@@ -8,13 +8,13 @@ Creates useful CloudWatch Alarms for an RDS Postgres database.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 
 ## Resources
 

--- a/rds-postgres/cloudwatch-alarms/versions.tf
+++ b/rds-postgres/cloudwatch-alarms/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/rds-postgres/parameter-group/README.md
+++ b/rds-postgres/parameter-group/README.md
@@ -8,13 +8,13 @@ Provision a Postgres-compatible RDS parameter group.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 
 ## Resources
 

--- a/rds-postgres/parameter-group/versions.tf
+++ b/rds-postgres/parameter-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/rds-postgres/primary-instance/README.md
+++ b/rds-postgres/primary-instance/README.md
@@ -8,14 +8,14 @@ Provision a Postgres database using AWS RDS.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 
 ## Modules
@@ -24,7 +24,7 @@ Provision a Postgres database using AWS RDS.
 |------|--------|---------|
 | <a name="module_alarms"></a> [alarms](#module\_alarms) | ../cloudwatch-alarms | n/a |
 | <a name="module_client_security_group"></a> [client\_security\_group](#module\_client\_security\_group) | ../../security-group | n/a |
-| <a name="module_customer_kms"></a> [customer\_kms](#module\_customer\_kms) | github.com/thoughtbot/terraform-aws-secrets//customer-managed-kms | v0.7.0 |
+| <a name="module_customer_kms"></a> [customer\_kms](#module\_customer\_kms) | github.com/thoughtbot/terraform-aws-secrets//customer-managed-kms | v0.8.0 |
 | <a name="module_parameter_group"></a> [parameter\_group](#module\_parameter\_group) | ../parameter-group | n/a |
 | <a name="module_server_security_group"></a> [server\_security\_group](#module\_server\_security\_group) | ../../security-group | n/a |
 
@@ -59,6 +59,7 @@ Provision a Postgres database using AWS RDS.
 | <a name="input_create_server_security_group"></a> [create\_server\_security\_group](#input\_create\_server\_security\_group) | Set to false to only use existing security groups | `bool` | `true` | no |
 | <a name="input_create_subnet_group"></a> [create\_subnet\_group](#input\_create\_subnet\_group) | Set to false to use existing subnet group | `bool` | `true` | no |
 | <a name="input_default_database"></a> [default\_database](#input\_default\_database) | Name of the default database | `string` | `"postgres"` | no |
+| <a name="input_enable_kms"></a> [enable\_kms](#input\_enable\_kms) | Enable KMS encryption | `bool` | `true` | no |
 | <a name="input_enabled_cloudwatch_logs_exports"></a> [enabled\_cloudwatch\_logs\_exports](#input\_enabled\_cloudwatch\_logs\_exports) | Set of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported | `list(string)` | `[]` | no |
 | <a name="input_engine"></a> [engine](#input\_engine) | RDS database engine; defaults to Postgres | `string` | `"postgres"` | no |
 | <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Version for RDS database engine | `string` | n/a | yes |

--- a/rds-postgres/primary-instance/main.tf
+++ b/rds-postgres/primary-instance/main.tf
@@ -156,5 +156,5 @@ locals {
     local.shared_vpc_security_group_ids
   )
 
-  primary_kms_key = var.kms_key_id == null ? module.customer_kms.kms_key_arn : var.kms_key_id
+  primary_kms_key = var.enable_kms ? (var.kms_key_id == null ? module.customer_kms.kms_key_arn : var.kms_key_id) : var.kms_key_id
 }

--- a/rds-postgres/primary-instance/main.tf
+++ b/rds-postgres/primary-instance/main.tf
@@ -52,7 +52,7 @@ resource "aws_db_instance" "this" {
 }
 
 module "customer_kms" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//customer-managed-kms?ref=v0.7.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//customer-managed-kms?ref=v0.8.0"
 
   name = var.identifier
 }

--- a/rds-postgres/primary-instance/variables.tf
+++ b/rds-postgres/primary-instance/variables.tf
@@ -59,6 +59,12 @@ variable "enabled_cloudwatch_logs_exports" {
   default     = []
 }
 
+variable "enable_kms" {
+  type        = bool
+  description = "Enable KMS encryption"
+  default     = true
+}
+
 variable "engine" {
   type        = string
   description = "RDS database engine; defaults to Postgres"

--- a/rds-postgres/primary-instance/versions.tf
+++ b/rds-postgres/primary-instance/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/rds-postgres/rds-postgres-login/README.md
+++ b/rds-postgres/rds-postgres-login/README.md
@@ -50,20 +50,20 @@ module "rds_admin_password" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_rotation"></a> [rotation](#module\_rotation) | github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function | v0.4.0 |
-| <a name="module_secret"></a> [secret](#module\_secret) | github.com/thoughtbot/terraform-aws-secrets//secret | v0.4.0 |
+| <a name="module_rotation"></a> [rotation](#module\_rotation) | github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function | v0.8.0 |
+| <a name="module_secret"></a> [secret](#module\_secret) | github.com/thoughtbot/terraform-aws-secrets//secret | v0.8.0 |
 
 ## Resources
 
@@ -84,7 +84,7 @@ module "rds_admin_password" {
 | <a name="input_admin_login_secret_arn"></a> [admin\_login\_secret\_arn](#input\_admin\_login\_secret\_arn) | ARN of a SecretsManager secret containing admin login | `string` | `null` | no |
 | <a name="input_admin_principals"></a> [admin\_principals](#input\_admin\_principals) | Principals allowed to peform admin actions (default: current account) | `list(string)` | `null` | no |
 | <a name="input_alternate_username"></a> [alternate\_username](#input\_alternate\_username) | Username for the alternate login used during rotation | `string` | `null` | no |
-| <a name="input_database"></a> [database](#input\_database) | The database instance for which a login will be managed | <pre>object({<br>    address    = string<br>    arn        = string<br>    engine     = string<br>    identifier = string<br>    name       = string<br>    port       = number<br>  })</pre> | n/a | yes |
+| <a name="input_database"></a> [database](#input\_database) | The database instance for which a login will be managed | <pre>object({<br>    address    = string<br>    arn        = string<br>    db_name    = string<br>    engine     = string<br>    identifier = string<br>    port       = number<br>  })</pre> | n/a | yes |
 | <a name="input_grants"></a> [grants](#input\_grants) | List of GRANT statements for this user | `list(string)` | n/a | yes |
 | <a name="input_read_principals"></a> [read\_principals](#input\_read\_principals) | Principals allowed to read the secret (default: current account) | `list(string)` | `null` | no |
 | <a name="input_replica"></a> [replica](#input\_replica) | Whether the login is for a replica instance | `bool` | `false` | no |

--- a/rds-postgres/rds-postgres-login/main.tf
+++ b/rds-postgres/rds-postgres-login/main.tf
@@ -1,5 +1,5 @@
 module "secret" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.4.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.8.0"
 
   admin_principals = var.admin_principals
   description      = "Postgres password for: ${local.full_name}"
@@ -9,7 +9,7 @@ module "secret" {
   trust_tags       = var.trust_tags
 
   initial_value = jsonencode({
-    dbname   = var.database.name
+    dbname   = var.database.db_name
     engine   = var.database.engine
     host     = var.database.address
     password = ""
@@ -19,7 +19,7 @@ module "secret" {
 }
 
 module "rotation" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.4.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.8.0"
 
   handler            = "lambda_function.lambda_handler"
   role_arn           = module.secret.rotation_role_arn

--- a/rds-postgres/rds-postgres-login/variables.tf
+++ b/rds-postgres/rds-postgres-login/variables.tf
@@ -27,9 +27,9 @@ variable "database" {
   type = object({
     address    = string
     arn        = string
+    db_name    = string
     engine     = string
     identifier = string
-    name       = string
     port       = number
   })
 }

--- a/rds-postgres/rds-postgres-login/versions.tf
+++ b/rds-postgres/rds-postgres-login/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/rds-postgres/replica/README.md
+++ b/rds-postgres/replica/README.md
@@ -8,13 +8,13 @@ Provision a Postgres database configured as a replica using AWS RDS.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 
 ## Modules
 

--- a/rds-postgres/replica/versions.tf
+++ b/rds-postgres/replica/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/security-group-ingress/versions.tf
+++ b/security-group-ingress/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/security-group/versions.tf
+++ b/security-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Switch this and dependent modules to the v5.x of the Terraform AWS provider to support the latest AWS features, like RDS' io2.

- Use updated `description` attribute name

Per the [documentation] for resource/aws_elasticache_replication_group

```
Remove availability_zones, number_cache_clusters,
replication_group_description arguments from configurations as they no
longer exist. Use preferred_cache_cluster_azs, num_cache_clusters, and
description, respectively, instead.
```

[documentation]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-5-upgrade#resourceaws_elasticache_replication_group

- Use `db_name` instead of `name`

Change name to db_name in configurations as name no longer exists.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-5-upgrade#use-db_name-instead-of-name

- Fix setting `instance_size`

```
│ Error: reading EC2 Instance Type: operation error EC2: DescribeInstanceTypes, https response error StatusCode: 400, RequestID: c975f413-b3d8-46e7-aad2-36dc1f38e063, api error InvalidInstanceType: The following supplied instance types do not exist: [2xlarge]
│
│   with module.production.module.redis_sidekiq[0].data.aws_ec2_instance_type.instance_attributes,
│   on .terraform/modules/production.redis_sidekiq/elasticache-redis/replication-group/main.tf line 226, in data "aws_ec2_instance_type" "instance_attributes":
│  226: data "aws_ec2_instance_type" "instance_attributes" {
```

---

This pull request was originally authored by @emilford (#28) and is being reopened because of a branch rename.