### PR TITLE
Remove engine_version ignore

### DIFF
--- a/elasticache-redis/replication-group/main.tf
+++ b/elasticache-redis/replication-group/main.tf
@@ -29,9 +29,7 @@ resource "aws_elasticache_replication_group" "this" {
   lifecycle {
     ignore_changes = [
       # The token should be rotated externally
-      auth_token,
-      # Minor upgrades will cause noise in diffs
-      engine_version
+      auth_token
     ]
   }
 }


### PR DESCRIPTION
Why this change is being made:
- We want to upgrade Redis for Hub. It's currently stuck on version 6 and we want to be able to add a var to set the version [see terraform-flightdeck-aws-application](https://github.com/thoughtbot/terraform-flightdeck-aws-application/pull/25) and use that for our Hub infrastructure [see infra](https://github.com/thoughtbot/thoughtbot-infra/pull/268)

What were the changes made to support this:
- remove ignored engine_version