### PR TITLE
Include apply_immediately variable for elasticache-redis replication group

### DIFF
--- a/elasticache-redis/replication-group/README.md
+++ b/elasticache-redis/replication-group/README.md
@@ -45,6 +45,7 @@ Provision a Redis cluster using AWS ElastiCache.
 | <a name="input_alarm_actions"></a> [alarm\_actions](#input\_alarm\_actions) | SNS topcis or other actions to invoke for alarms | `list(object({ arn = string }))` | `[]` | no |
 | <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | CIDR blocks allowed to access the database | `list(string)` | `[]` | no |
 | <a name="input_allowed_security_group_ids"></a> [allowed\_security\_group\_ids](#input\_allowed\_security\_group\_ids) | Security group allowed to access the database | `list(string)` | `[]` | no |
+| <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Set to true to apply changes immediately | `bool` | `false` | no |
 | <a name="input_at_rest_encryption_enabled"></a> [at\_rest\_encryption\_enabled](#input\_at\_rest\_encryption\_enabled) | Set to false to disable encryption at rest | `bool` | `true` | no |
 | <a name="input_client_security_group_name"></a> [client\_security\_group\_name](#input\_client\_security\_group\_name) | Override the name for the security group; defaults to identifer | `string` | `""` | no |
 | <a name="input_create_client_security_group"></a> [create\_client\_security\_group](#input\_create\_client\_security\_group) | Set to false to only use existing security groups | `bool` | `true` | no |

--- a/elasticache-redis/replication-group/main.tf
+++ b/elasticache-redis/replication-group/main.tf
@@ -1,6 +1,7 @@
 resource "aws_elasticache_replication_group" "this" {
   replication_group_id = coalesce(var.replication_group_id, var.name)
 
+  apply_immediately           = var.apply_immediately
   at_rest_encryption_enabled  = var.at_rest_encryption_enabled
   automatic_failover_enabled  = local.replica_enabled
   description                 = var.description

--- a/elasticache-redis/replication-group/variables.tf
+++ b/elasticache-redis/replication-group/variables.tf
@@ -1,3 +1,9 @@
+variable "apply_immediately" {
+  type        = bool
+  description = "Set to true to apply changes immediately"
+  default     = false
+}
+
 variable "alarm_actions" {
   type        = list(object({ arn = string }))
   description = "SNS topcis or other actions to invoke for alarms"


### PR DESCRIPTION
For changes effective immediately instead of having to wait for the maintenance window.