### PR TITLE
add optional replica_region input for aws_db_instance region

### DIFF
--- a/rds-postgres/replica/README.md
+++ b/rds-postgres/replica/README.md
@@ -48,8 +48,8 @@ Provision a Postgres database configured as a replica using AWS RDS.
 | <a name="input_parameter_group_name"></a> [parameter\_group\_name](#input\_parameter\_group\_name) | Name of the RDS parameter group; defaults to identifier | `string` | `""` | no |
 | <a name="input_performance_insights_enabled"></a> [performance\_insights\_enabled](#input\_performance\_insights\_enabled) | Set to false to disable performance insights | `bool` | `true` | no |
 | <a name="input_publicly_accessible"></a> [publicly\_accessible](#input\_publicly\_accessible) | Set to true to access this database outside the VPC | `bool` | `false` | no |
-| <a name="input_replicate_source_db"></a> [replicate\_source\_db](#input\_replicate\_source\_db) | Identifier of the primary database instance to replicate | `string` | n/a | yes |
 | <a name="input_replica_region"></a> [replica\_region](#input\_replica\_region) | Region where the replica will be managed; defaults to the provider region when null | `string` | `null` | no |
+| <a name="input_replicate_source_db"></a> [replicate\_source\_db](#input\_replicate\_source\_db) | Identifier of the primary database instance to replicate | `string` | n/a | yes |
 | <a name="input_storage_encrypted"></a> [storage\_encrypted](#input\_storage\_encrypted) | Set to false to disable on-disk encryption | `bool` | `true` | no |
 | <a name="input_subnet_group_name"></a> [subnet\_group\_name](#input\_subnet\_group\_name) | Name of the RDS subnet group (only for cross-region replication) | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to created resources | `map(string)` | `{}` | no |

--- a/rds-postgres/replica/README.md
+++ b/rds-postgres/replica/README.md
@@ -49,6 +49,7 @@ Provision a Postgres database configured as a replica using AWS RDS.
 | <a name="input_performance_insights_enabled"></a> [performance\_insights\_enabled](#input\_performance\_insights\_enabled) | Set to false to disable performance insights | `bool` | `true` | no |
 | <a name="input_publicly_accessible"></a> [publicly\_accessible](#input\_publicly\_accessible) | Set to true to access this database outside the VPC | `bool` | `false` | no |
 | <a name="input_replicate_source_db"></a> [replicate\_source\_db](#input\_replicate\_source\_db) | Identifier of the primary database instance to replicate | `string` | n/a | yes |
+| <a name="input_replica_region"></a> [replica\_region](#input\_replica\_region) | Region where the replica will be managed; defaults to the provider region when null | `string` | `null` | no |
 | <a name="input_storage_encrypted"></a> [storage\_encrypted](#input\_storage\_encrypted) | Set to false to disable on-disk encryption | `bool` | `true` | no |
 | <a name="input_subnet_group_name"></a> [subnet\_group\_name](#input\_subnet\_group\_name) | Name of the RDS subnet group (only for cross-region replication) | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to created resources | `map(string)` | `{}` | no |

--- a/rds-postgres/replica/main.tf
+++ b/rds-postgres/replica/main.tf
@@ -10,6 +10,7 @@ resource "aws_db_instance" "this" {
   parameter_group_name         = local.parameter_group_name
   performance_insights_enabled = var.performance_insights_enabled
   publicly_accessible          = var.publicly_accessible
+  region                       = var.replica_region
   replicate_source_db          = var.replicate_source_db
   skip_final_snapshot          = true
   storage_encrypted            = var.storage_encrypted

--- a/rds-postgres/replica/variables.tf
+++ b/rds-postgres/replica/variables.tf
@@ -59,6 +59,12 @@ variable "replicate_source_db" {
   type        = string
 }
 
+variable "replica_region" {
+  description = "Region where the replica will be managed; defaults to the provider region when null"
+  type        = string
+  default     = null
+}
+
 variable "storage_encrypted" {
   type        = bool
   default     = true


### PR DESCRIPTION
Add optional replica_region input for RDS replica placement

This introduces a new module input, replica_region, and passes it through to aws_db_instance using the resource-level region argument.

When replica_region is unset, the module continues to use the AWS provider's configured region, so existing consumers keep the same behaviour. When it is set, callers can place the replica in a specific region without introducing a separate provider alias for this module.